### PR TITLE
For NPU Sample, add flexibility in device creation options and fix Generic ML Device logic

### DIFF
--- a/Samples/DirectMLNpuInference/main.cpp
+++ b/Samples/DirectMLNpuInference/main.cpp
@@ -26,10 +26,10 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
 
     // Populate helper structures based on above flags
     std::vector<GUID> dxGuidAllowedAttributes = {}; // Attributes here are ok, having them does not disquality a device
-    std::vector<GUID> dxGuidRequireAllAttributes = {}; // All attributes here must be present for a device to be use  
+    std::vector<GUID> dxGuidRequireAllAttributes = {}; // All attributes here must be present for a device to be used
     std::vector<GUID> dxGuidDisallowedAttributes = {}; // Any attribute here disqualifies a device from being used
 
-    // By default allow for these compute attributes
+    // By default allow for these generic attribute
     dxGuidAllowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GENERIC_ML);
 
     allowGraphicsAttributes ?
@@ -71,7 +71,7 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
         
         for (auto& allowedGuid : iteratingAdapterList)
         {
-            if (adapter != nullptr) continue;
+            if (adapter != nullptr) break;
             
             ComPtr<IDXCoreAdapterList> adapterList;
             THROW_IF_FAILED(factory->CreateAdapterList(1, &allowedGuid, IID_PPV_ARGS(&adapterList)));

--- a/Samples/DirectMLNpuInference/main.cpp
+++ b/Samples/DirectMLNpuInference/main.cpp
@@ -16,9 +16,13 @@ using Microsoft::WRL::ComPtr;
 void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** commandQueueOut, IDMLDevice** dmlDeviceOut)
 {
     // Useful Flags to chage to allow, require, and disallow certain attributes of devices for testing.
-    const bool allowGraphicsCapabilities = false;
-    const bool requireComputeDevice = true;
-    const bool requireGenericMLDevice = false;
+    // Modify to require for generic ML devices on a needed basis.
+    const bool allowGraphicsAttributes = false;
+    const bool allowComputeAttributes = true;
+    const bool requireComputeAttributes = false;
+    const bool requireGenericMLAttributes = false;
+
+    assert(!(!allowComputeAttributes && requireComputeAttributes));
 
     // Populate helper structures based on above flags
     std::vector<GUID> dxGuidAllowedAttributes = {};
@@ -26,12 +30,15 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
     std::vector<GUID> dxGuidDisallowedAttributes = {};
 
     // By default allow for these compute attributes
-    dxGuidAllowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE);
     dxGuidAllowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GENERIC_ML);
 
-    allowGraphicsCapabilities ? 
+    allowGraphicsAttributes ?
         dxGuidAllowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRAPHICS) :
         dxGuidDisallowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRAPHICS);
+
+    allowComputeAttributes ?
+        dxGuidAllowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE) :
+        dxGuidDisallowedAttributes.push_back(DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE);
 
     if (requireComputeDevice)
     {

--- a/Samples/DirectMLNpuInference/main.cpp
+++ b/Samples/DirectMLNpuInference/main.cpp
@@ -79,7 +79,7 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
                     if (currentGpuAdapter->IsAttributeSupported(disallowedGuid)) { isAdapterValid = false; }
                 }
 
-                // filter out adapters that doesn match all required attributes
+                // filter out adapters that doesn't match all required attributes
                 for (auto& requiredGuid : dxGuidRequiredAttributes)
                 {
                     if (!currentGpuAdapter->IsAttributeSupported(requiredGuid)) { isAdapterValid = false; }

--- a/Samples/DirectMLNpuInference/main.cpp
+++ b/Samples/DirectMLNpuInference/main.cpp
@@ -59,7 +59,10 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
     ComPtr<IDXCoreAdapter> adapter;
     if (factory)
     {
-        for (auto& allowedGuid : dxGuidAllowedAttributes)
+        // If there's any required attributes, save time by only passing in required attributes instead.
+        std::vector<GUID> iteratingAdapterList = dxGuidRequiredAttributes.empty() ? dxGuidAllowedAttributes : dxGuidRequiredAttributes;
+        
+        for (auto& allowedGuid : iteratingAdapterList)
         {
             if (adapter != nullptr) continue;
             
@@ -114,7 +117,7 @@ void InitializeDirectML(ID3D12Device1** d3dDeviceOut, ID3D12CommandQueue** comma
                 );
             if (d3d12CreateDevice)
             {
-                THROW_IF_FAILED(d3d12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_1_0_CORE, IID_PPV_ARGS(&d3dDevice)));
+                THROW_IF_FAILED(d3d12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_1_0_GENERIC, IID_PPV_ARGS(&d3dDevice)));
             }
         }
     }


### PR DESCRIPTION
Expand NPU sample's capabilities for creating devices based on attributes.

More specifically, allow options to filter based on allowed, unallowed, and required attributes. Then add some flags for the most commonly needed options for this sample.

The logic for how each interacts with CreateAdapterList is a bit unconventional since CreateAdapterList ANDs the passed in attributes.

Tested locally on Intel NPU.